### PR TITLE
feat: implement HTTP MCP endpoint and adapt coding_env to MCP (RFC 003)

### DIFF
--- a/envs/coding_env/server/app.py
+++ b/envs/coding_env/server/app.py
@@ -5,10 +5,17 @@
 # LICENSE file in the root directory of this source tree.
 
 """
-FastAPI application for the Coding Environment.
+FastAPI application for the Coding Environment with MCP Support.
 
 This module creates an HTTP server that exposes the PythonCodeActEnv
-over HTTP and WebSocket endpoints, compatible with EnvClient.
+over HTTP, WebSocket, and MCP endpoints.
+
+The environment supports two interaction styles:
+1. **MCP Tools** (recommended): Use ListToolsAction/CallToolAction or POST /mcp
+   - execute_code(code): Execute Python code
+   - check_syntax(code): Check syntax without executing
+
+2. **Legacy CodeAction**: For backward compatibility with existing clients
 
 Usage:
     # Development (with auto-reload):
@@ -17,24 +24,27 @@ Usage:
     # Production:
     uvicorn envs.coding_env.server.app:app --host 0.0.0.0 --port 8000 --workers 4
 
-    # Or run directly:
-    python -m envs.coding_env.server.app
+    # Using MCP client:
+    from openenv.core.mcp_client import MCPToolClient
+    with MCPToolClient(base_url="http://localhost:8000") as env:
+        env.reset()
+        result = env.call_tool("execute_code", code="print('Hello!')")
 """
 
 from openenv.core.env_server import create_app
+from openenv.core.env_server.mcp_types import CallToolAction, CallToolObservation
 
-from coding_env.models import CodeAction, CodeObservation
 from coding_env.server.python_codeact_env import PythonCodeActEnv
 
-# Create the app with web interface and README integration
-# Pass the class (factory) instead of an instance for WebSocket session support
-app = create_app(PythonCodeActEnv, CodeAction, CodeObservation, env_name="coding_env")
-
-
-if __name__ == "__main__":
-    import uvicorn
-
-    uvicorn.run(app, host="0.0.0.0", port=8000)
+# Create the app with MCP support
+# Using CallToolAction/CallToolObservation for MCP compatibility
+# Legacy CodeAction is still supported via _step_impl
+app = create_app(
+    PythonCodeActEnv,
+    CallToolAction,
+    CallToolObservation,
+    env_name="coding_env",
+)
 
 
 def main():

--- a/envs/coding_env/server/python_codeact_env.py
+++ b/envs/coding_env/server/python_codeact_env.py
@@ -5,61 +5,157 @@
 # LICENSE file in the root directory of this source tree.
 
 """
-Python Code Action Environment.
+Python Code Action Environment with MCP Support.
 
 This module provides a server-side environment implementation for executing
-Python code actions using PyExecutor.
+Python code actions using PyExecutor. It supports both:
+- MCP tool-calling style (via ListToolsAction/CallToolAction)
+- Legacy CodeAction for backward compatibility
+
+MCP Tools exposed:
+- `execute_code(code)`: Execute Python code and return results
+- `check_syntax(code)`: Check Python code syntax without executing
 """
 
+import ast
 import uuid
+from typing import Any, Optional
 
-from openenv.core.env_server.interfaces import Action, Environment, Observation
+from fastmcp import FastMCP
+
+from openenv.core.env_server.mcp_environment import MCPEnvironment
+from openenv.core.env_server.types import Action, Observation
 from .python_executor import PyExecutor
 
 from ..models import CodeAction, CodeObservation, CodeState
 from .transforms import create_safe_coding_transform
 
 
-class PythonCodeActEnv(Environment):
+class PythonCodeActEnv(MCPEnvironment):
     """
     Python Code Action Environment for executing code and tracking state.
 
-    This environment executes Python code submitted as CodeAction during step,
-    maintains the last exit code in its state, and returns results wrapped
-    in CodeObservation.
+    This environment executes Python code and exposes functionality through MCP tools:
+    - `execute_code(code)`: Execute Python code and return stdout/stderr/exit_code
+    - `check_syntax(code)`: Check Python code syntax without executing
 
-    Args:
-        transform: Optional transform to apply to observations
-        additional_imports: List of additional module imports to authorize
-                          (e.g., ["numpy", "pandas", "matplotlib"])
+    It also maintains backward compatibility with the legacy CodeAction for
+    existing clients.
 
-    Example:
+    Example using MCP tools:
+        >>> from openenv.core.env_server.mcp_types import ListToolsAction, CallToolAction
+        >>> env = PythonCodeActEnv()
+        >>> env.reset()
+        >>>
+        >>> # List available tools
+        >>> obs = env.step(ListToolsAction())
+        >>> print([t.name for t in obs.tools])  # ["execute_code", "check_syntax"]
+        >>>
+        >>> # Execute code via MCP tool
+        >>> obs = env.step(CallToolAction(
+        ...     tool_name="execute_code",
+        ...     arguments={"code": "print('Hello, World!')"}
+        ... ))
+        >>> print(obs.result)  # {"stdout": "Hello, World!\\n", "stderr": "", "exit_code": 0}
+
+    Example using legacy CodeAction (backward compatible):
         >>> env = PythonCodeActEnv()
         >>> obs = env.reset()
         >>> action = CodeAction(code="print('Hello, World!')")
         >>> obs = env.step(action)
-        >>> print(obs.stdout)  # "Hello, World!\n"
-        >>> print(obs.exit_code)  # 0
-        >>> print(env.state.last_exit_code)  # 0
+        >>> print(obs.stdout)  # "Hello, World!\\n"
     """
 
-    def __init__(
-        self,
-    ):
-        self.transform = create_safe_coding_transform()
+    def __init__(self):
+        """Initialize the coding environment with MCP server and tools."""
+        # Create executor first (needed by tools)
         self._executor = PyExecutor()
         self._state = CodeState()
+        self.transform = create_safe_coding_transform()
 
-    def reset(self) -> Observation:
+        # Create MCP server and define tools
+        mcp = FastMCP("coding_env")
+
+        # Store reference to self for tool closures
+        env_self = self
+
+        @mcp.tool
+        def execute_code(code: str) -> dict:
+            """
+            Execute Python code and return results.
+
+            The execution context is persistent within an episode - variables and
+            functions defined in previous steps are available in subsequent steps.
+
+            Args:
+                code: Python code to execute
+
+            Returns:
+                Dictionary with:
+                - stdout: Standard output from the code execution
+                - stderr: Standard error from the code execution
+                - exit_code: 0 for success, non-zero for errors
+            """
+            result = env_self._executor.run(code)
+
+            # Update state
+            env_self._state.step_count += 1
+            env_self._state.last_exit_code = result.exit_code
+
+            return {
+                "stdout": result.stdout,
+                "stderr": result.stderr,
+                "exit_code": result.exit_code,
+            }
+
+        @mcp.tool
+        def check_syntax(code: str) -> dict:
+            """
+            Check Python code syntax without executing.
+
+            Args:
+                code: Python code to check
+
+            Returns:
+                Dictionary with:
+                - valid: True if syntax is valid, False otherwise
+                - error: Error message if syntax is invalid, None otherwise
+                - line: Line number of error if applicable
+            """
+            try:
+                ast.parse(code)
+                return {"valid": True, "error": None, "line": None}
+            except SyntaxError as e:
+                return {
+                    "valid": False,
+                    "error": str(e.msg) if e.msg else str(e),
+                    "line": e.lineno,
+                }
+
+        # Pass the MCP server to the base class
+        super().__init__(mcp)
+
+    def reset(
+        self,
+        seed: Optional[int] = None,
+        episode_id: Optional[str] = None,
+        **kwargs: Any,
+    ) -> Observation:
         """
         Reset environment and start fresh execution session.
+
+        Args:
+            seed: Optional random seed (unused)
+            episode_id: Optional episode ID to use
 
         Returns:
             Initial observation with empty stdout/stderr and exit_code=0
         """
         # Initialize fresh state
-        self._state = CodeState(episode_id=str(uuid.uuid4()), step_count=0)
-        # Add last_exit_code to state
+        self._state = CodeState(
+            episode_id=episode_id or str(uuid.uuid4()),
+            step_count=0,
+        )
         self._state.last_exit_code = 0
 
         # Reset executor to clear any previously defined variables/functions
@@ -73,43 +169,56 @@ class PythonCodeActEnv(Environment):
             stdout="",
             stderr="",
             exit_code=0,
+            metadata={"status": "ready"},
         )
 
         return self._apply_transform(observation)
 
-    def step(self, action: Action) -> Observation:
+    def _step_impl(
+        self,
+        action: Action,
+        timeout_s: Optional[float] = None,
+        **kwargs: Any,
+    ) -> Observation:
         """
-        Execute code action and return observation.
+        Handle non-MCP actions (legacy CodeAction support).
+
+        This method provides backward compatibility with the legacy CodeAction
+        interface. New clients should use MCP tools instead.
 
         Args:
             action: CodeAction containing the code to execute
 
         Returns:
             CodeObservation with execution results (stdout, stderr, exit_code)
-
-        Raises:
-            ValueError: If action is not a CodeAction instance
         """
-        if not isinstance(action, CodeAction):
-            raise ValueError(f"Expected CodeAction, got {type(action)}")
+        if isinstance(action, CodeAction):
+            # Execute the code using PyExecutor
+            result = self._executor.run(action.code)
 
-        # Execute the code using PyExecutor
-        result = self._executor.run(action.code)
+            # Update state
+            self._state.step_count += 1
+            self._state.last_exit_code = result.exit_code
 
-        # Update state
-        self._state.step_count += 1
-        self._state.last_exit_code = result.exit_code
+            # Create observation from execution result
+            observation = CodeObservation(
+                stdout=result.stdout,
+                stderr=result.stderr,
+                exit_code=result.exit_code,
+                metadata={"last_code": action.code},
+            )
 
-        # Create observation from execution result
-        # Include code in metadata for transform reward calculation
-        observation = CodeObservation(
-            stdout=result.stdout,
-            stderr=result.stderr,
-            exit_code=result.exit_code,
-            metadata={"last_code": action.code},
+            return self._apply_transform(observation)
+
+        # Unknown action type
+        return Observation(
+            done=False,
+            reward=0.0,
+            metadata={
+                "error": f"Unknown action type: {type(action).__name__}. "
+                "Use ListToolsAction, CallToolAction, or CodeAction."
+            },
         )
-
-        return self._apply_transform(observation)
 
     @property
     def state(self) -> CodeState:


### PR DESCRIPTION
## Summary

Implement HTTP MCP endpoint at POST /mcp as specified in RFC 003, enabling direct MCP access for production/inference use cases. Also adapts coding_env to use MCPEnvironment with FastMCP tools (execute_code, check_syntax).

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] New environment
- [ ] Refactoring

## Alignment Checklist

Before submitting, verify:
- [x] I have read `.claude/docs/PRINCIPLES.md` and this PR aligns with our principles
- [x] I have checked `.claude/docs/INVARIANTS.md` and no invariants are violated
- [x] I have run `/pre-submit-pr` (or `bash .claude/hooks/lint.sh` and tests) and addressed all issues

## RFC Status
- [ ] Not required (bug fix, docs, minor refactoring)
- [x] RFC exists: RFC 003 (MCP Support)
- [ ] RFC needed (will create before merge)

## Test Plan

1. **Unit tests (automated)**:
   
## Claude Code Review
<!-- If you used Claude Code for this PR, paste the output of /alignment-review here -->
<!-- If not applicable, write "N/A" -->
