### PR TITLE
tbench2 env server: enable idle-session reaper to reclaim leaked slots

### DIFF
--- a/envs/tbench2_env/server/app.py
+++ b/envs/tbench2_env/server/app.py
@@ -30,12 +30,16 @@ Usage:
 Environment Variables:
     TB2_MODE: Execution mode - "local" (default), "docker", or "auto"
     MAX_CONCURRENT_ENVS: Maximum concurrent WebSocket sessions (default: 8)
+    SESSION_IDLE_TIMEOUT_S: Idle seconds before a session is reaped and its
+        container reclaimed (default: 3600). Guards against leaked slots from
+        half-open WebSocket connections that never fire a clean disconnect.
 """
 
 import os
 
 
 try:
+    from openenv.core.env_server import ConcurrencyConfig
     from openenv.core.env_server.http_server import create_app
 
     # In-repo imports
@@ -46,6 +50,7 @@ except Exception as e:  # pragma: no cover
     from models import Tbench2Action, Tbench2Observation
 
     # Standalone imports (when environment is standalone with openenv from pip)
+    from openenv.core.env_server import ConcurrencyConfig
     from openenv.core.env_server.http_server import create_app
     from server.tbench2_env_environment import (
         Tbench2DockerEnvironment,
@@ -72,13 +77,17 @@ else:
 
 # Create the app with web interface and README integration
 max_concurrent = int(os.getenv("MAX_CONCURRENT_ENVS", "8"))
+session_idle_timeout = float(os.getenv("SESSION_IDLE_TIMEOUT_S", "3600"))
 
 app = create_app(
     _DEFAULT_ENVIRONMENT,
     Tbench2Action,
     Tbench2Observation,
     env_name="tbench2_env" + _ENV_SUFFIX,
-    max_concurrent_envs=max_concurrent,
+    concurrency_config=ConcurrencyConfig(
+        max_concurrent_envs=max_concurrent,
+        session_timeout=session_idle_timeout,
+    ),
 )
 
 


### PR DESCRIPTION
## What

The `tbench2_env` server now enables the core idle-session reaper by passing an explicit `ConcurrencyConfig(max_concurrent_envs=..., session_timeout=...)` to `create_app`, instead of the bare `max_concurrent_envs=` argument. A new `SESSION_IDLE_TIMEOUT_S` env var (default `3600`) controls the reap interval.

## Why

The `/mcp` WebSocket handler releases its session slot and Docker container only in a `finally` block, which runs solely on a **clean** socket close. Half-open or uncleanly-dropped connections never raise `WebSocketDisconnect`, so `receive_text()` blocks forever, the `finally` never runs, and the session slot + its Docker container leak.

Under sustained load these leaks accumulate over roughly a day until all `MAX_CONCURRENT_ENVS` slots are permanently held. New episodes then deadlock on `CAPACITY_REACHED` and the only recovery is a manual env-server restart.

Passing a bare `max_concurrent_envs` maps to `ConcurrencyConfig(session_timeout=None)` in the core server, which **disables** `_reap_idle_sessions`. Supplying an explicit `session_timeout` re-enables the reaper so stale sessions are evicted and their containers reclaimed automatically, without operator intervention.

## Notes

- Default `SESSION_IDLE_TIMEOUT_S=3600` preserves existing behavior for short-lived sessions while bounding leaked slots.
- Single-file change scoped to `envs/tbench2_env/server/app.py`; no change to the core server or to the on-the-wire protocol.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-file server bootstrap change with a conservative default timeout; no protocol or core server edits.
> 
> **Overview**
> The **tbench2_env** server now passes an explicit **`ConcurrencyConfig`** to **`create_app`** (with **`max_concurrent_envs`** and **`session_timeout`**) instead of only **`max_concurrent_envs`**, which turns on the core idle-session reaper that was previously off when **`session_timeout`** was unset.
> 
> A new **`SESSION_IDLE_TIMEOUT_S`** env var (default **3600**) sets how long a session can sit idle before it is reaped so its WebSocket slot and Docker container are released. That targets leaks from half-open **`/mcp`** WebSocket connections that never hit a clean disconnect, which could otherwise hold all **`MAX_CONCURRENT_ENVS`** slots until a manual restart.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit adc5d447aefc39ef33915dfc108d80f512e15d08. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->