### PR TITLE
fix(finqa_env): prevent path traversal via agent-supplied company/table names

### DIFF
--- a/envs/finqa_env/server/tools.py
+++ b/envs/finqa_env/server/tools.py
@@ -48,6 +48,34 @@ class FinQATools:
             if os.path.isdir(os.path.join(self.companies_path, d))
         ]
 
+    def _resolve_within(self, *parts: str) -> str | None:
+        """
+        Join agent-supplied path components under ``companies_path`` and confirm the
+        result stays inside it.
+
+        The tool arguments (``company_name``, ``table_name``) are supplied by the agent
+        over the MCP boundary. Joining them into a filesystem path without a containment
+        check allows ``..`` traversal to read files outside the data directory. This
+        rejects any such escape.
+
+        Args:
+            parts (`str`):
+                Path components to join beneath ``companies_path``.
+
+        Returns:
+            `str` or `None`: the resolved absolute path if it stays within
+            ``companies_path``, otherwise `None`.
+        """
+        root = os.path.realpath(self.companies_path)
+        candidate = os.path.realpath(os.path.join(self.companies_path, *parts))
+        try:
+            if candidate != root and os.path.commonpath([root, candidate]) == root:
+                return candidate
+        except ValueError:
+            # Raised when paths cannot be compared (e.g. different drives on Windows).
+            pass
+        return None
+
     def execute_tool(
         self, tool_name: str, tool_args: Dict[str, Any]
     ) -> Tuple[str, bool]:
@@ -82,9 +110,9 @@ class FinQATools:
         Returns:
             JSON list of table names
         """
-        company_path = os.path.join(self.companies_path, company_name)
+        company_path = self._resolve_within(company_name)
 
-        if not os.path.isdir(company_path):
+        if company_path is None or not os.path.isdir(company_path):
             available = self.get_available_companies()
             return (
                 f"Error: '{company_name}' not found. Available companies: {available}"
@@ -109,9 +137,9 @@ class FinQATools:
         Returns:
             JSON string with table metadata (description, columns, dtypes, unique values)
         """
-        company_path = os.path.join(self.companies_path, company_name)
+        company_path = self._resolve_within(company_name)
 
-        if not os.path.isdir(company_path):
+        if company_path is None or not os.path.isdir(company_path):
             available = self.get_available_companies()
             return (
                 f"Error: '{company_name}' not found. Available companies: {available}"
@@ -211,12 +239,10 @@ class FinQATools:
 
         # Clean table name
         cleaned_table_name = table_name.replace(".txt", "").replace(".json", "")
-        table_path = os.path.join(
-            self.companies_path, company_name, f"{cleaned_table_name}.json"
-        )
+        table_path = self._resolve_within(company_name, f"{cleaned_table_name}.json")
 
-        if not os.path.isfile(table_path):
-            return f"Error: Table file not found at {table_path}"
+        if table_path is None or not os.path.isfile(table_path):
+            return f"Error: Table file not found for '{company_name}/{table_name}'"
 
         try:
             # Load table and execute query

--- a/tests/envs/test_finqa_environment.py
+++ b/tests/envs/test_finqa_environment.py
@@ -553,6 +553,52 @@ class TestTools:
         assert "Error" in result
 
 
+class TestToolsPathTraversal:
+    """Agent-supplied company/table names must not escape the data directory (CWE-22).
+
+    Self-contained (synthetic data, no downloaded dataset needed) so it runs in CI.
+    """
+
+    @pytest.fixture
+    def tools(self, tmp_path):
+        pytest.importorskip("pandas")
+        from envs.finqa_env.server.tools import FinQATools
+
+        company = tmp_path / "input_companies" / "acme"
+        company.mkdir(parents=True)
+        (company / "revenue.json").write_text('[{"x": 1}]')
+        # A file the agent must never be able to reach, placed outside input_companies/.
+        (tmp_path / "secret.json").write_text('[{"password": "leaked-secret"}]')
+        return FinQATools(str(tmp_path))
+
+    def test_legit_access_still_works(self, tools):
+        assert "Error" not in tools.get_descriptions("acme")
+        assert "leaked" not in tools.sql_query(
+            "acme", "revenue", "SELECT x FROM revenue WHERE x = 1"
+        )
+
+    def test_get_descriptions_rejects_traversal(self, tools):
+        for evil in ["..", "../..", "../../../../etc"]:
+            result = tools.get_descriptions(evil)
+            assert "Error" in result
+            assert "secret" not in result
+
+    def test_sql_query_rejects_company_traversal(self, tools):
+        result = tools.sql_query(
+            "..", "secret", "SELECT password FROM secret WHERE 1 = 1"
+        )
+        assert "leaked-secret" not in result
+
+    def test_sql_query_rejects_table_traversal(self, tools):
+        result = tools.sql_query(
+            "acme", "../../secret", "SELECT password FROM x WHERE 1 = 1"
+        )
+        assert "leaked-secret" not in result
+
+    def test_get_table_info_rejects_traversal(self, tools):
+        assert "Error" in tools.get_table_info("../..", "whatever")
+
+
 @pytest.mark.skipif(_integration_skip, reason=_integration_reason)
 class TestEnvironment:
     """Test environment logic using MCP actions."""


### PR DESCRIPTION
## Summary
The FinQA env's MCP tools (`get_descriptions`, `get_table_info`, `sql_query`) build a filesystem path from the agent-supplied `company_name`/`table_name` and guard it only with an existence check (`os.path.isdir`/`os.path.isfile`), not a containment check. An agent can pass `..` components over the MCP boundary to enumerate directories and read arbitrary `.json` files **outside** the data directory (e.g. withheld answer data for other episodes → reward hacking, or any `.json` mounted into the container). This adds a `_resolve_within()` helper that rejects any path escaping `companies_path`, applied to all three tools.

## Type of Change
- [x] Bug fix

## Alignment Checklist
- [x] I have read `.claude/docs/PRINCIPLES.md` and this PR aligns with our principles
- [x] I have checked `.claude/docs/INVARIANTS.md` and no invariants are violated
- [x] I have run lint (`ruff format --check`, `ruff check`, `usort check`) and the finqa tests — all pass

## RFC Status
- [x] Not required (bug fix, no API change)

## Details
`envs/finqa_env/server/tools.py` — the sinks:
```python
company_path = os.path.join(self.companies_path, company_name)      # get_descriptions / get_table_info
table_path   = os.path.join(self.companies_path, company_name, f"{cleaned_table_name}.json")  # sql_query
```
`company_name`/`table_name` come straight from the MCP `CallToolAction` arguments, and the only validation is `os.path.isdir`/`isfile` — an existence check, not containment. `..` traversal therefore escapes `companies_path`.

Fix: a small `_resolve_within(*parts)` helper resolves the joined path with `os.path.realpath` and returns `None` unless it stays within `companies_path` (via `os.path.commonpath`). Each tool now rejects a `None` result. Legitimate company/table access is unchanged; the fix runs before any file read. Blast radius is confined to the env's own container/process, but it breaks the intended "companies are a closed set from `get_available_companies()`" boundary.

## Test Plan
New self-contained test class `TestToolsPathTraversal` in `tests/envs/test_finqa_environment.py` (synthetic `input_companies/` in `tmp_path` + a `secret.json` outside it; needs only pandas, **not** the downloaded dataset, so it runs in CI — unlike the dataset-gated `TestTools`).

Verified red → green against a synthetic layout:

**Before the fix (vulnerable):**
```
get_descriptions('..')                         -> ["secret"]                      # enumerated parent dir
sql_query('..', 'secret', 'SELECT password …') -> [{"password":"leaked-secret"}]  # read file outside root
```
**After the fix (blocked, legit access intact):**
```
legit get_descriptions('acme')                 -> ok (no error)
legit sql_query('acme','revenue', …)           -> ok (no error)
get_descriptions('..')                         -> Error (no leak)
sql_query('..','secret', …)                    -> Error: Table file not found …   (no leak)
sql_query('acme','../../secret', …)            -> Error (no leak)
get_table_info('../..','whatever')             -> Error
```
Full file: `67 passed, 16 skipped` (skips = dataset-gated integration tests). `ruff format --check`, `ruff check`, `usort check` all clean on the changed files.

## Claude Code Review
Self-reviewed the diff for scope and the containment logic (realpath + commonpath, `ValueError` guard for cross-drive on Windows, applied uniformly to all three sinks). No new dependencies; no public API change; docstring follows the HF doc-builder format.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Security fix on agent-controlled filesystem access in the FinQA env; behavior change only for malicious or malformed path components, with low blast radius but high importance if traversal was exploitable.
> 
> **Overview**
> **Closes a CWE-22 path traversal hole** in FinQA MCP tools where `company_name` and `table_name` from the agent were joined into filesystem paths with only existence checks, allowing `..` to read JSON outside `input_companies/`.
> 
> Adds `_resolve_within()` using `realpath` and `commonpath` to ensure resolved paths stay under `companies_path`, and wires it into `get_descriptions`, `get_table_info`, and `sql_query` (rejecting escapes before any read). `sql_query` now returns a generic “table not found” message instead of exposing the resolved path.
> 
> Adds CI-friendly `TestToolsPathTraversal` with synthetic layout and a parent-dir `secret.json` to confirm legitimate access still works and traversal via company or table names is blocked.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 069bc8452c08d1766b7e769ecfa537b56953586b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->