### PR TITLE
fix(discovery): store env discovery cache per-user, not in world-writable tmp

### DIFF
--- a/src/openenv/auto/_discovery.py
+++ b/src/openenv/auto/_discovery.py
@@ -20,8 +20,9 @@ import importlib.metadata
 import importlib.resources
 import json
 import logging
+import os
 import re
-import tempfile
+import stat
 from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Any, Type
@@ -336,6 +337,46 @@ def _create_env_info_from_package(
     )
 
 
+def _default_cache_file() -> Path:
+    """
+    Return the per-user discovery cache file path.
+
+    Uses a per-user cache directory (``$XDG_CACHE_HOME`` or ``~/.cache``) rather than a
+    shared, world-writable temporary directory. A fixed path under the shared temp dir
+    lets another local user pre-create the cache file and redirect discovery to
+    attacker-controlled import paths (`import_module` on a cached `client_module_path`).
+    """
+    base = os.environ.get("XDG_CACHE_HOME")
+    root = Path(base) if base else Path.home() / ".cache"
+    return root / "openenv" / "discovery_cache.json"
+
+
+def _is_trusted_cache_file(path: Path) -> bool:
+    """
+    Return whether *path* is safe to load.
+
+    On POSIX the file must be owned by the current user and not writable by group or
+    others, so a cache file planted by another user is ignored rather than trusted.
+
+    Args:
+        path (`Path`):
+            The cache file to check.
+
+    Returns:
+        `bool`: `True` if the file is owned by the current user and not
+        group/other-writable (always `True` on non-POSIX platforms).
+    """
+    if os.name != "posix":
+        return True
+    try:
+        info = path.stat()
+    except OSError:
+        return False
+    return info.st_uid == os.getuid() and not (
+        info.st_mode & (stat.S_IWGRP | stat.S_IWOTH)
+    )
+
+
 class EnvironmentDiscovery:
     """
     Auto-discovery system for OpenEnv environments using installed packages.
@@ -346,7 +387,7 @@ class EnvironmentDiscovery:
     def __init__(self):
         """Initialize discovery system."""
         self._cache: dict[str, EnvironmentInfo] | None = None
-        self._cache_file = Path(tempfile.gettempdir()) / "openenv_discovery_cache.json"
+        self._cache_file = _default_cache_file()
 
     def _discover_installed_packages(self) -> dict[str, EnvironmentInfo]:
         """
@@ -411,6 +452,16 @@ class EnvironmentDiscovery:
         if not self._cache_file.exists():
             return None
 
+        # Only trust a cache file owned by the current user. This prevents another
+        # local user from planting a file that would redirect discovery (and the
+        # subsequent import_module) to attacker-controlled modules/classes.
+        if not _is_trusted_cache_file(self._cache_file):
+            logger.warning(
+                f"Ignoring discovery cache {self._cache_file}: not owned by the "
+                "current user or writable by group/others."
+            )
+            return None
+
         try:
             with open(self._cache_file, "r") as f:
                 cache_data = json.load(f)
@@ -437,8 +488,12 @@ class EnvironmentDiscovery:
             for env_key, env_info in environments.items():
                 cache_data[env_key] = asdict(env_info)
 
+            self._cache_file.parent.mkdir(parents=True, exist_ok=True)
             with open(self._cache_file, "w") as f:
                 json.dump(cache_data, f, indent=2)
+            # Restrict to the owner so the cache cannot be tampered with by others.
+            if os.name == "posix":
+                os.chmod(self._cache_file, 0o600)
 
         except Exception as e:
             logger.warning(f"Failed to save discovery cache: {e}")

--- a/src/openenv/auto/_discovery.py
+++ b/src/openenv/auto/_discovery.py
@@ -351,12 +351,35 @@ def _default_cache_file() -> Path:
     return root / "openenv" / "discovery_cache.json"
 
 
+def _is_trusted_stat(info: os.stat_result) -> bool:
+    """
+    Return whether the file *info* describes is safe to load.
+
+    On POSIX the file must be owned by the current user and not writable by group or
+    others, so a cache file planted by another user is ignored rather than trusted.
+
+    Args:
+        info (`os.stat_result`):
+            Metadata for the file being considered.
+
+    Returns:
+        `bool`: `True` if the file is owned by the current user and not
+        group/other-writable (always `True` on non-POSIX platforms).
+    """
+    if os.name != "posix":
+        return True
+    return info.st_uid == os.getuid() and not (
+        info.st_mode & (stat.S_IWGRP | stat.S_IWOTH)
+    )
+
+
 def _is_trusted_cache_file(path: Path) -> bool:
     """
     Return whether *path* is safe to load.
 
-    On POSIX the file must be owned by the current user and not writable by group or
-    others, so a cache file planted by another user is ignored rather than trusted.
+    Prefer `_open_trusted_cache`, which checks the descriptor it hands back. This
+    variant resolves the path a second time, so on its own it cannot promise that
+    the file inspected is the file later read.
 
     Args:
         path (`Path`):
@@ -369,12 +392,44 @@ def _is_trusted_cache_file(path: Path) -> bool:
     if os.name != "posix":
         return True
     try:
-        info = path.stat()
+        return _is_trusted_stat(path.stat())
     except OSError:
         return False
-    return info.st_uid == os.getuid() and not (
-        info.st_mode & (stat.S_IWGRP | stat.S_IWOTH)
-    )
+
+
+def _open_trusted_cache(path: Path) -> int | None:
+    """
+    Open *path* for reading and return the descriptor only if it is trustworthy.
+
+    Checking a path and then opening it are two separate resolutions, and an
+    attacker who can write in the cache directory can swap the file for a symlink
+    in between, so the file that was vetted is not the file that gets read.
+    ``O_NOFOLLOW`` refuses a symlink outright and ``fstat`` inspects the descriptor
+    itself, which makes the ownership check and the read the same object.
+
+    Args:
+        path (`Path`):
+            The cache file to open.
+
+    Returns:
+        `int` or `None`: an open read-only descriptor the caller must close, or
+        `None` if the file is missing, is a symlink, or is not owned by the
+        current user.
+    """
+    flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        fd = os.open(path, flags)
+    except OSError:
+        # Missing, unreadable, or a symlink (ELOOP under O_NOFOLLOW).
+        return None
+    try:
+        if not _is_trusted_stat(os.fstat(fd)):
+            os.close(fd)
+            return None
+    except OSError:
+        os.close(fd)
+        return None
+    return fd
 
 
 class EnvironmentDiscovery:
@@ -449,21 +504,22 @@ class EnvironmentDiscovery:
         Returns:
             Dictionary of env_key -> EnvironmentInfo, or None if cache invalid
         """
-        if not self._cache_file.exists():
-            return None
-
         # Only trust a cache file owned by the current user. This prevents another
         # local user from planting a file that would redirect discovery (and the
-        # subsequent import_module) to attacker-controlled modules/classes.
-        if not _is_trusted_cache_file(self._cache_file):
-            logger.warning(
-                f"Ignoring discovery cache {self._cache_file}: not owned by the "
-                "current user or writable by group/others."
-            )
+        # subsequent import_module) to attacker-controlled modules/classes. The
+        # descriptor is what gets vetted and then read, so the file cannot be
+        # swapped for a symlink after the check.
+        fd = _open_trusted_cache(self._cache_file)
+        if fd is None:
+            if self._cache_file.exists():
+                logger.warning(
+                    f"Ignoring discovery cache {self._cache_file}: not owned by "
+                    "the current user, writable by group/others, or a symlink."
+                )
             return None
 
         try:
-            with open(self._cache_file, "r") as f:
+            with os.fdopen(fd, "r") as f:
                 cache_data = json.load(f)
 
             # Reconstruct EnvironmentInfo objects
@@ -489,11 +545,15 @@ class EnvironmentDiscovery:
                 cache_data[env_key] = asdict(env_info)
 
             self._cache_file.parent.mkdir(parents=True, exist_ok=True)
-            with open(self._cache_file, "w") as f:
+            # Create the file owner-only rather than writing it and narrowing the
+            # mode afterwards: `open()` applies the umask, so a `chmod` after the
+            # fact leaves a window in which the cache is world-readable. Refuse to
+            # follow a symlink here too, so a planted link cannot redirect the
+            # write.
+            flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC | getattr(os, "O_NOFOLLOW", 0)
+            fd = os.open(self._cache_file, flags, 0o600)
+            with os.fdopen(fd, "w") as f:
                 json.dump(cache_data, f, indent=2)
-            # Restrict to the owner so the cache cannot be tampered with by others.
-            if os.name == "posix":
-                os.chmod(self._cache_file, 0o600)
 
         except Exception as e:
             logger.warning(f"Failed to save discovery cache: {e}")

--- a/tests/envs/test_discovery.py
+++ b/tests/envs/test_discovery.py
@@ -12,12 +12,18 @@ Tests cover:
 5. Helper functions (_normalize_env_name, _is_hub_url, etc.)
 """
 
+import json
+import os
+import stat
+import tempfile
 from unittest.mock import Mock, patch
 
 from openenv.auto._discovery import (
     _create_env_info_from_package,
+    _default_cache_file,
     _infer_class_name,
     _is_hub_url,
+    _is_trusted_cache_file,
     _normalize_env_name,
     EnvironmentDiscovery,
     EnvironmentInfo,
@@ -302,6 +308,80 @@ class TestEnvironmentDiscovery:
         # Clean up
         discovery.clear_cache()
         assert not discovery._cache_file.exists()
+
+
+class TestCacheSecurity:
+    """The discovery cache must not be plantable/redirectable by another local user.
+
+    A world-writable shared path let a local attacker pre-create the cache and
+    redirect discovery's later ``import_module`` to attacker-chosen modules/classes
+    (CWE-377 insecure temp file + CWE-427 uncontrolled load path).
+    """
+
+    def test_cache_file_is_per_user_not_shared_tmp(self):
+        path = _default_cache_file()
+        assert tempfile.gettempdir() not in str(path)
+        assert path.parent.name == "openenv"
+
+    def test_world_writable_cache_is_not_trusted(self, tmp_path):
+        f = tmp_path / "cache.json"
+        f.write_text("{}")
+        os.chmod(f, 0o666)
+        # Rejected on POSIX; non-POSIX has no ownership model so it stays trusted.
+        assert _is_trusted_cache_file(f) is (os.name != "posix")
+
+    def test_owner_only_cache_is_trusted(self, tmp_path):
+        f = tmp_path / "cache.json"
+        f.write_text("{}")
+        os.chmod(f, 0o600)
+        assert _is_trusted_cache_file(f) is True
+
+    def test_load_cache_ignores_world_writable_file(self, tmp_path):
+        planted = tmp_path / "cache.json"
+        planted.write_text(
+            json.dumps(
+                {
+                    "evil": {
+                        "env_key": "evil",
+                        "name": "evil",
+                        "package_name": "openenv-evil",
+                        "version": "1.0.0",
+                        "description": "",
+                        "client_module_path": "os",
+                        "client_class_name": "system",
+                        "action_class_name": "A",
+                        "observation_class_name": "O",
+                        "default_image": "i",
+                    }
+                }
+            )
+        )
+        os.chmod(planted, 0o666)
+        discovery = EnvironmentDiscovery()
+        discovery._cache_file = planted
+        if os.name == "posix":
+            assert discovery._load_cache() is None
+
+    def test_saved_cache_is_owner_only(self, tmp_path):
+        discovery = EnvironmentDiscovery()
+        discovery._cache_file = tmp_path / "sub" / "cache.json"
+        env = EnvironmentInfo(
+            env_key="t",
+            name="t",
+            package_name="openenv-t",
+            version="1.0.0",
+            description="",
+            client_module_path="t.client",
+            client_class_name="T",
+            action_class_name="A",
+            observation_class_name="O",
+            default_image="i",
+        )
+        discovery._save_cache({"t": env})
+        assert discovery._cache_file.exists()
+        if os.name == "posix":
+            assert stat.S_IMODE(discovery._cache_file.stat().st_mode) == 0o600
+        assert discovery._load_cache() is not None
 
 
 class TestGlobalDiscovery:

--- a/tests/envs/test_discovery.py
+++ b/tests/envs/test_discovery.py
@@ -383,6 +383,89 @@ class TestCacheSecurity:
             assert stat.S_IMODE(discovery._cache_file.stat().st_mode) == 0o600
         assert discovery._load_cache() is not None
 
+    def test_symlinked_cache_is_refused(self, tmp_path):
+        """The trust check must apply to the object actually read.
+
+        Checking the path and then opening it separately leaves a window: an
+        attacker who can write in the cache directory swaps the verified file
+        for a symlink before the read. Opening with ``O_NOFOLLOW`` and
+        inspecting the resulting descriptor closes it, so a symlink is refused
+        outright rather than followed to a file that was never checked.
+        """
+        if os.name != "posix":
+            return
+
+        target = tmp_path / "attacker.json"
+        target.write_text(
+            json.dumps(
+                {
+                    "evil": {
+                        "env_key": "evil",
+                        "name": "evil",
+                        "package_name": "openenv-evil",
+                        "version": "1.0.0",
+                        "description": "",
+                        "client_module_path": "os",
+                        "client_class_name": "system",
+                        "action_class_name": "A",
+                        "observation_class_name": "O",
+                        "default_image": "i",
+                    }
+                }
+            )
+        )
+        os.chmod(target, 0o600)
+
+        link = tmp_path / "cache.json"
+        link.symlink_to(target)
+
+        discovery = EnvironmentDiscovery()
+        discovery._cache_file = link
+        assert discovery._load_cache() is None
+
+    def test_save_does_not_rely_on_a_follow_up_chmod(self, tmp_path):
+        """The cache must be created owner-only, not widened then narrowed.
+
+        ``open()`` honours the umask, so creating the file and calling
+        ``chmod`` afterwards leaves a window in which the cache is
+        world-readable. Creating the descriptor with the mode already set
+        removes it; `os.chmod` is made to fail here so the test only passes if
+        nothing depends on it.
+        """
+        if os.name != "posix":
+            return
+
+        discovery = EnvironmentDiscovery()
+        discovery._cache_file = tmp_path / "sub" / "cache.json"
+        env = EnvironmentInfo(
+            env_key="t",
+            name="t",
+            package_name="openenv-t",
+            version="1.0.0",
+            description="",
+            client_module_path="t.client",
+            client_class_name="T",
+            action_class_name="A",
+            observation_class_name="O",
+            default_image="i",
+        )
+
+        real_umask = os.umask(0)
+        real_chmod = os.chmod
+
+        def _no_chmod(*args, **kwargs):
+            raise AssertionError("cache permissions must not depend on chmod")
+
+        os.chmod = _no_chmod
+        try:
+            discovery._save_cache({"t": env})
+        finally:
+            os.chmod = real_chmod
+            os.umask(real_umask)
+
+        assert discovery._cache_file.exists()
+        assert stat.S_IMODE(discovery._cache_file.stat().st_mode) == 0o600
+
 
 class TestGlobalDiscovery:
     """Test global discovery instance management."""


### PR DESCRIPTION
## Summary
`EnvironmentDiscovery` stored its cache at a fixed, world-writable path in the shared temp directory: `tempfile.gettempdir() / "openenv_discovery_cache.json"`. On a multi-user host, another local user can pre-create that file with attacker-chosen `client_module_path` / `client_class_name`; the victim's `discover(use_cache=True)` (the default) then loads it and rebuilds `EnvironmentInfo`, and a later `get_client_class()` / `get_action_class()` / `get_observation_class()` calls `importlib.import_module(client_module_path)` + `getattr(...)` on the attacker-supplied names. This moves the cache to a per-user location and refuses to trust a foreign/world-writable cache file.

## Type of Change
- [x] Bug fix

## Alignment Checklist
- [x] I have read `.claude/docs/PRINCIPLES.md` and this PR aligns with our principles
- [x] I have checked `.claude/docs/INVARIANTS.md` and no invariants are violated
- [x] I have run lint (`ruff format --check`, `ruff check`, `usort check`) and the discovery/auto-env tests — all pass

## RFC Status
- [x] Not required (bug fix, no public API change)

## Details
`src/openenv/auto/_discovery.py`:
```python
self._cache_file = Path(tempfile.gettempdir()) / "openenv_discovery_cache.json"  # shared, world-writable, fixed name
```
`_load_cache()` `json.load`s that file and rebuilds `EnvironmentInfo(**env_data)` with no ownership or integrity check; `_save_cache()` writes it with default permissions. The trust issue is CWE-377 (insecure temp file) escalating to CWE-427 (uncontrolled load path) via `import_module`.

Fix (three small, layered changes):
- **Per-user location** — `_default_cache_file()` returns `$XDG_CACHE_HOME/openenv/…` or `~/.cache/openenv/discovery_cache.json`, removing the shared-writable premise entirely.
- **Trust check on load** — `_is_trusted_cache_file()` (POSIX) requires the file be owned by the current user and not group/other-writable; otherwise `_load_cache()` logs and returns `None` (falls back to live discovery). No-op on non-POSIX.
- **Restrictive write** — `_save_cache()` creates the parent dir and `chmod 0o600`s the file.

Behavior is unchanged for the normal single-user case; `clear_cache()` and the cache round-trip work exactly as before.

## Test Plan
New `TestCacheSecurity` class in `tests/envs/test_discovery.py`:
- `test_cache_file_is_per_user_not_shared_tmp` — path is not under the shared temp dir.
- `test_world_writable_cache_is_not_trusted` / `test_owner_only_cache_is_trusted` — the guard.
- `test_load_cache_ignores_world_writable_file` — a planted world-writable cache pointing `client_module_path` at `os` (→ `system`) is ignored, not loaded.
- `test_saved_cache_is_owner_only` — saved file is `0600` and round-trips.

Verified (synthetic): a world-writable planted cache → `_load_cache()` returns `None` (logs "Ignoring discovery cache … not owned by the current user"); legit own-file round-trip loads and is `0600`. `101 passed, 8 skipped` across `test_discovery.py` + `test_auto_env.py`; `ruff format --check`, `ruff check`, `usort check` clean.

## Claude Code Review
Self-reviewed: layered fix (relocate + guard + perms), POSIX-gated so Windows behavior is unchanged, no public API change, no new dependency, docstrings in HF doc-builder format.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes trust boundaries and file I/O around cached metadata that drives dynamic imports; behavior is POSIX-gated but mistakes could break discovery or cache use on multi-user hosts.
> 
> **Overview**
> **Hardens the environment discovery JSON cache** so a local attacker cannot poison `client_module_path` / class names that later flow into `import_module`.
> 
> The cache path moves from a **fixed file under the shared temp directory** to **`$XDG_CACHE_HOME/openenv/discovery_cache.json`** (or `~/.cache/...`). On load, discovery now opens the cache via **`_open_trusted_cache`**: POSIX checks that the opened descriptor is a regular file owned by the current user and not group/other-writable, with **`O_NOFOLLOW`** and **`O_NONBLOCK`** to block symlink swaps and FIFO hangs. Untrusted caches are logged and ignored (live discovery still runs).
> 
> **Writes** no longer truncate an existing path in place: they create a **pid-suffixed temp file with mode `0600` and `O_EXCL`**, then **`os.replace`** into the final name so permissions and atomicity hold even when overwriting a world-writable file.
> 
> Tests add an **autouse fixture** redirecting the default cache into `tmp_path`, plus **`TestCacheSecurity`** covering permissions, planted caches, symlinks, FIFO refusal, and save-without-follow-up-`chmod`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a6533f5d82cd392c1efea2870ea7294a15036f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->