### PR TITLE
Fix duplicate venv copy in server Dockerfile template 

### DIFF
--- a/.claude/skills/generate-openenv-env/assets/openenv_env_template/server/Dockerfile
+++ b/.claude/skills/generate-openenv-env/assets/openenv_env_template/server/Dockerfile
@@ -54,16 +54,27 @@ RUN --mount=type=cache,target=/root/.cache/uv \
         uv sync --no-editable; \
     fi
 
+# Move the venv out of /app/env so it isn't nested inside the directory we
+# copy wholesale below. Copying /app/env/.venv separately AND /app/env would
+# otherwise ship the venv twice (once at /app/.venv, once at
+# /app/env/.venv), roughly doubling the image size.
+RUN mv /app/env/.venv /app/.venv
+
 # Final runtime stage
 FROM ${BASE_IMAGE}
 
 WORKDIR /app
 
 # Copy the virtual environment from builder
-COPY --from=builder /app/env/.venv /app/.venv
+COPY --from=builder /app/.venv /app/.venv
 
-# Copy the environment code
+# Copy the environment code (no longer contains .venv, see builder stage)
 COPY --from=builder /app/env /app/env
+
+# Recreate a .venv symlink inside the env directory for tools (e.g. `uv run`,
+# editors) that expect the virtual environment alongside the project, without
+# storing a second physical copy of it.
+RUN ln -s /app/.venv /app/env/.venv
 
 # Set PATH to use the virtual environment
 ENV PATH="/app/.venv/bin:$PATH"

--- a/src/openenv/cli/templates/openenv_env/server/Dockerfile
+++ b/src/openenv/cli/templates/openenv_env/server/Dockerfile
@@ -50,16 +50,27 @@ RUN --mount=type=cache,target=/root/.cache/uv \
         uv sync --no-editable; \
     fi
 
+# Move the venv out of /app/env so it isn't nested inside the directory we
+# copy wholesale below. Copying /app/env/.venv separately AND /app/env would
+# otherwise ship the venv twice (once at /app/.venv, once at
+# /app/env/.venv), roughly doubling the image size.
+RUN mv /app/env/.venv /app/.venv
+
 # Final runtime stage
 FROM ${BASE_IMAGE}
 
 WORKDIR /app
 
 # Copy the virtual environment from builder
-COPY --from=builder /app/env/.venv /app/.venv
+COPY --from=builder /app/.venv /app/.venv
 
-# Copy the environment code
+# Copy the environment code (no longer contains .venv, see builder stage)
 COPY --from=builder /app/env /app/env
+
+# Recreate a .venv symlink inside the env directory for tools (e.g. `uv run`,
+# editors) that expect the virtual environment alongside the project, without
+# storing a second physical copy of it.
+RUN ln -s /app/.venv /app/env/.venv
 
 # Set PATH to use the virtual environment
 ENV PATH="/app/.venv/bin:$PATH"


### PR DESCRIPTION
Fixes #1021

## Problem
`openenv init` generates a Dockerfile whose final stage copies the built
virtualenv twice: once explicitly, and once again implicitly because `uv sync`
places `.venv` inside `/app/env`, and the next layer copies `/app/env`
wholesale — nesting a second full copy of the venv inside it. This roughly
doubles the image size (confirmed via `dive` in the issue: two ~523-524MB
layers for what should be one).

## Fix
- Move `.venv` out of `/app/env` in the **builder** stage, before the final
  stage's copies happen, so the wholesale `COPY --from=builder /app/env
  /app/env` no longer contains a nested venv.
- Recreate a `.venv` symlink inside `/app/env` in the runtime stage (pointing
  at the single real copy at `/app/.venv`) so tooling that expects the venv
  alongside the project (e.g. `uv run`) still works, with no second physical
  copy on disk.
- Applied identically to `src/openenv/cli/templates/openenv_env/server/Dockerfile`
  and `.claude/skills/generate-openenv-env/assets/openenv_env_template/server/Dockerfile`,
  since these two files were already kept byte-for-byte identical (aside from
  license header) and would otherwise drift.

## Testing
Built a fresh env from the fixed template (`openenv init` + `docker build`) and
confirmed via `docker history` that the venv is now copied once, not twice:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-only Dockerfile template change with no runtime application logic; behavior is intended to stay the same aside from smaller images.
> 
> **Overview**
> Fixes **roughly doubled Docker image size** for environments built from `openenv init` by stopping the server Dockerfile from shipping the same virtualenv twice.
> 
> In the **builder** stage, `.venv` is moved from `/app/env/.venv` to `/app/.venv` before the runtime stage copies `/app/env` wholesale, so that layer no longer embeds a second full copy of the venv alongside the explicit `COPY` to `/app/.venv`. The runtime stage adds a **symlink** `/app/env/.venv` → `/app/.venv` so tools that expect a venv next to the project (e.g. `uv run`) still work without a second on-disk copy.
> 
> The same change is applied in both `src/openenv/cli/templates/openenv_env/server/Dockerfile` and `.claude/skills/generate-openenv-env/assets/openenv_env_template/server/Dockerfile` to keep them aligned.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c2910b7562daf6738c51a3c3af40ef35e9c9eaf2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->