### PR TITLE
chore: add a justfile for common dev commands

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,0 +1,23 @@
+# Common development commands for OpenEnv. Run `just` to list recipes.
+
+export PYTHONPATH := "src:envs"
+
+# List available recipes
+default:
+    @just --list
+
+# Install dependencies
+install:
+    uv sync --all-extras
+
+# Run the test suite (excludes envs that need special setup, like CI)
+test:
+    uv run pytest tests/ -v --tb=short \
+        --ignore=tests/envs/test_browsergym_environment.py \
+        --ignore=tests/envs/test_dipg_environment.py \
+        --ignore=tests/envs/test_websearch_environment.py \
+        -m "not integration and not network and not docker"
+
+# Run a single test file or pattern, e.g. `just test-one tests/core/test_agentic_harness_types.py`
+test-one target:
+    uv run pytest {{target}} -v --tb=short


### PR DESCRIPTION
Wraps the commands already documented in `CLAUDE.md` so they are discoverable via `just --list` and harder to get subtly wrong.

| recipe | what it runs |
|---|---|
| `just install` | `uv sync --all-extras` |
| `just test` | the CI invocation, same `--ignore` set and marker filter |
| `just test-one <target>` | one file or pattern |
| `just lint` | usort check + ruff format --check + ruff check |
| `just format` | usort format + ruff format |
| `just docs-sync` | `scripts/sync_env_docs.py --fix` |

`just test` deliberately mirrors `.github/workflows/test.yml` rather than being a simpler `pytest tests/`, so a green local run means the same thing CI does.

Independent of the RFC 005 work I have open alongside this; split out so it can land or be dropped on its own.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Developer-only task runner; no runtime, auth, or deployment behavior changes.
> 
> **Overview**
> Adds a root **`justfile`** so common OpenEnv dev workflows are listed via `just` instead of copying commands from docs.
> 
> It sets **`PYTHONPATH=src:envs`** for recipes and wires **`just install`** to `uv sync --all-extras`. **`just test`** runs pytest with the same ignored env tests and marker filter as **`.github/workflows/test.yml`**, so local runs match CI. **`just test-one <target>`** runs a single file or pattern with the same pytest verbosity options.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3c04f884500e775512795bc08f5655da7038074. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->