### PR TITLE
docs: fix Environment Builder client example to use .sync() bootstrap handle

### DIFF
--- a/.claude/skills/generate-openenv-env/references/openenv-docs-environment-builder.md
+++ b/.claude/skills/generate-openenv-env/references/openenv-docs-environment-builder.md
@@ -373,12 +373,12 @@ For an end-to-end example of using your environment, see the [Quick Start](quick
 ```python
 from envs.my_env import MyAction, MyEnv
 
-# Create environment from Docker image
-client = MyEnv.from_docker_image("my-env:latest")
-# Or, connect to the remote space on Hugging Face
-client = MyEnv.from_hub("my-org/my-env")
-# Or, connect to the local server
-client = MyEnv(base_url="http://localhost:8000")
+# Create environment from Docker image (starts a container)
+client = MyEnv.from_docker_image("my-env:latest").sync()
+# Or, run the image of a Hugging Face Space locally
+client = MyEnv.from_env("my-org/my-env").sync()
+# Or, connect to an already running server
+client = MyEnv(base_url="http://localhost:8000").sync()
 
 # Use context manager for automatic cleanup (recommended)
 with client:
@@ -398,11 +398,36 @@ with client:
 
 # Or manually manage the connection
 try:
-    client = MyEnv(base_url="http://localhost:8000")
+    client = MyEnv(base_url="http://localhost:8000").sync()
     result = client.reset()
     result = client.step(MyAction(command="test", parameters={}))
 finally:
     client.close()
+```
+
+`from_docker_image()` and `from_env()` do not return a connected client. They
+return a lazy bootstrap handle, and nothing starts until you resolve it: chain
+`.sync()` for a synchronous client (as above), or `await` the handle from async
+code. Using the handle directly in a `with` block raises
+`TypeError: '_BootstrapResult' object does not support the context manager protocol`.
+
+The equivalent async usage is:
+
+```python
+import asyncio
+
+from envs.my_env import MyAction, MyEnv
+
+
+async def main():
+    client = await MyEnv.from_docker_image("my-env:latest")
+    async with client:
+        result = await client.reset()
+        result = await client.step(MyAction(command="test", parameters={}))
+        state = await client.state()
+
+
+asyncio.run(main())
 ```
 
 ## Troubleshooting

--- a/docs/source/getting_started/environment-builder.md
+++ b/docs/source/getting_started/environment-builder.md
@@ -20,7 +20,7 @@ Already familiar with OpenEnv? Here's the 8-step process at a glance:
 | 5 | `uv run --project . server` | Start local dev server for testing |
 | 6 | `openenv validate` | Validate environment structure |
 | 7 | `openenv push` | Deploy to Hugging Face Hub |
-| 8 | Share the URL! | Others use via `MyEnv.from_hub("you/my-env")` |
+| 8 | Share it! | Others use via `MyEnv.from_env("you/my-env").sync()` |
 
 ### CLI Quick Reference
 
@@ -405,12 +405,12 @@ Here is a simple example of using your environment:
 ```python
 from envs.my_env import MyAction, MyEnv
 
-# Create environment from Docker image
-client = MyEnv.from_docker_image("my-env:latest")
-# Or, connect to the remote space on Hugging Face
-client = MyEnv.from_hub("my-org/my-env")
-# Or, connect to the local server
-client = MyEnv(base_url="http://localhost:8000")
+# Create environment from Docker image (starts a container)
+client = MyEnv.from_docker_image("my-env:latest").sync()
+# Or, run the image of a Hugging Face Space locally
+client = MyEnv.from_env("my-org/my-env").sync()
+# Or, connect to an already running server
+client = MyEnv(base_url="http://localhost:8000").sync()
 
 # Use context manager for automatic cleanup (recommended)
 with client:
@@ -430,12 +430,39 @@ with client:
 
 # Or manually manage the connection
 try:
-    client = MyEnv(base_url="http://localhost:8000")
+    client = MyEnv(base_url="http://localhost:8000").sync()
     result = client.reset()
     result = client.step(MyAction(command="test", parameters={}))
 finally:
     client.close()
 ```
+
+`from_docker_image()` and `from_env()` do not return a connected client. They
+return a lazy bootstrap handle, and nothing starts until you resolve it: chain
+`.sync()` for a synchronous client (as above), or `await` the handle from async
+code. Using the handle directly in a `with` block raises
+`TypeError: '_BootstrapResult' object does not support the context manager protocol`.
+
+The equivalent async usage is:
+
+```python
+import asyncio
+
+from envs.my_env import MyAction, MyEnv
+
+
+async def main():
+    client = await MyEnv.from_docker_image("my-env:latest")
+    async with client:
+        result = await client.reset()
+        result = await client.step(MyAction(command="test", parameters={}))
+        state = await client.state()
+
+
+asyncio.run(main())
+```
+
+See [Async vs Sync Usage](../guides/async-sync) for when to prefer each style.
 
 ## Nice work! You've now built and used your own OpenEnv environment.
 

--- a/docs/source/guides/task-api.md
+++ b/docs/source/guides/task-api.md
@@ -229,7 +229,7 @@ Note that the Task API is served over HTTP while episodes typically run over the
 From a training or evaluation loop, discovery and episode control then compose naturally:
 
 ```python
-with LatexOCREnv.from_docker_image("latex-ocr-env:latest") as env:
+with LatexOCREnv.from_docker_image("latex-ocr-env:latest").sync() as env:
     total = env.num_tasks("test")
     for index in range(total):
         result = env.reset(split="test", index=index)

--- a/tests/test_core/test_generic_client.py
+++ b/tests/test_core/test_generic_client.py
@@ -591,6 +591,67 @@ class TestSyncBootstrapConstructors:
 
         mock_provider.stop_container.assert_called_once_with()
 
+    _RESET_RESPONSE = (
+        '{"type": "response", "data": {"observation": {"ready": true}, '
+        '"reward": 0.0, "done": false}}'
+    )
+
+    def test_documented_sync_usage_with_block_and_reset(self, mock_provider):
+        """The Environment Builder docs' sync example works end-to-end (issue #1118).
+
+        `client = MyEnv.from_docker_image(...).sync()` followed by
+        `with client: client.reset()` must connect on the sync loop, return a
+        concrete StepResult (not a coroutine), and release the container on exit.
+        """
+        fake_connect, sockets = self._fake_ws_connect()
+
+        with patch("openenv.core.env_client.ws_connect", side_effect=fake_connect):
+            client = GenericEnvClient.from_docker_image(
+                image="my-env:latest",
+                provider=mock_provider,
+            ).sync()
+            sockets[0].recv.return_value = self._RESET_RESPONSE
+
+            with client:
+                result = client.reset()
+
+        if asyncio.iscoroutine(result):
+            result.close()
+            pytest.fail("client.reset() returned a coroutine in synchronous code")
+        assert isinstance(result, StepResult)
+        assert result.observation == {"ready": True}
+        assert result.done is False
+        mock_provider.start_container.assert_called_once_with("my-env:latest")
+        mock_provider.stop_container.assert_called_once_with()
+
+    @pytest.mark.asyncio
+    async def test_documented_async_usage_async_with_and_reset(self, mock_provider):
+        """The Environment Builder docs' async example works end-to-end (issue #1118).
+
+        `client = await MyEnv.from_docker_image(...)` followed by
+        `async with client: await client.reset()` must reuse the connection
+        opened by the handle and release the container on exit.
+        """
+        fake_connect, sockets = self._fake_ws_connect()
+
+        with patch("openenv.core.env_client.ws_connect", side_effect=fake_connect):
+            client = await GenericEnvClient.from_docker_image(
+                image="my-env:latest",
+                provider=mock_provider,
+            )
+            assert isinstance(client, GenericEnvClient)
+            sockets[0].recv.return_value = self._RESET_RESPONSE
+
+            async with client:
+                result = await client.reset()
+
+        assert isinstance(result, StepResult)
+        assert result.observation == {"ready": True}
+        # `async with` on an already-connected client must not open a second socket.
+        assert len(sockets) == 1
+        mock_provider.start_container.assert_called_once_with("my-env:latest")
+        mock_provider.stop_container.assert_called_once_with()
+
 
 class TestBaseUrlProperty:
     """Test the public read-only base_url property (issue #935)."""


### PR DESCRIPTION
## Summary

The "Use Your Environment" example in the Environment Builder guide uses `MyEnv.from_docker_image(...)` directly in a `with` block, which fails with `TypeError: '_BootstrapResult' object does not support the context manager protocol` (or `'coroutine' object ...` on 0.4.1). `from_docker_image()` / `from_env()` return a lazy bootstrap handle that must be `await`ed or chained with `.sync()` (#343, #959); the example predates that change and also references a `MyEnv.from_hub()` that does not exist on `EnvClient`. This PR fixes the docs (including the Quick Reference Card row and the skill reference copy of the page) and adds tests that exercise the documented bootstrap/context-manager patterns.

Fixes #1118

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation
- [ ] New environment
- [ ] Refactoring

## Alignment Checklist

Before submitting, verify:
- [x] I have read `.claude/docs/PRINCIPLES.md` and this PR aligns with our principles
- [x] I have checked `.claude/docs/INVARIANTS.md` and no invariants are violated
- [x] I have run `/pre-submit-pr` (or `bash .claude/hooks/lint.sh` and tests) and addressed all issues

## RFC Status
- [x] Not required (bug fix, docs, minor refactoring)
- [ ] RFC exists: #___
- [ ] RFC needed (will create before merge)

## Changes

- `docs/source/getting_started/environment-builder.md`: use `.sync()` on all constructor lines and the manual-cleanup block, replace `from_hub()` with `from_env(...).sync()` (both in the example and in the Quick Reference Card row), explain the lazy handle, and add the async equivalent with a link to the Async vs Sync guide.
- `.claude/skills/generate-openenv-env/references/openenv-docs-environment-builder.md`: same edit applied to the skill's reference copy of this page. `generate-openenv-env/SKILL.md` instructs the agent to always read this file, so leaving it stale would keep generating the old API.
- `docs/source/guides/task-api.md`: same one-token `.sync()` fix in the `with LatexOCREnv.from_docker_image(...)` example.
- `tests/test_core/test_generic_client.py`: two tests in `TestSyncBootstrapConstructors` that exercise the documented sync and async bootstrap/context-manager patterns (`from_docker_image(...).sync()` + `with`, and `await from_docker_image(...)` + `async with`, each followed by `reset()`) through the real dispatch path with a fake websocket and mock provider, asserting a concrete `StepResult`, a single socket, and container release on exit.

No runtime code is changed.

## Test Plan

- Reproduced every variant against `registry.hf.space/openenv-echo-env:latest` with real Docker at `ced9d73c`. The corrected sync and async snippets both complete reset/step/state end to end.
- `PYTHONPATH=src:envs uv run pytest tests/test_core/test_generic_client.py -k documented -v`: 2 passed.
- `bash .claude/hooks/test.sh`: 1519 passed, 95 skipped.
- `ruff check`, `ruff format --check`, `usort check` clean on touched files; `python scripts/sync_env_docs.py --check` clean.
- Reviewers can verify with the same pytest command above, or by running the updated docs snippet against any built env image.

## Out of scope (noted for follow-up)

- Several env READMEs use `env = X.from_docker_image(...)` then `env.reset()` without `.sync()`, which raises `AttributeError`.
- `LocalDockerProvider.stop_container` lets `subprocess.TimeoutExpired` escape `close()` when `docker stop` exceeds 10s (images using `sh -c` as PID 1 always hit the SIGTERM grace period).
- Whether `_BootstrapResult` should support `with` / `async with` directly is an API decision left to maintainers.

## Claude Code Review

`/alignment-review` was not run. Validation was done with `bash .claude/hooks/test.sh` plus the lint commands from `CLAUDE.md`; results are in the Test Plan above.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and test-only changes; no production client or server code is modified.
> 
> **Overview**
> Fixes **#1118** by aligning Environment Builder and related docs with the lazy **bootstrap handle** API: `from_docker_image()` / `from_env()` must be resolved with **`.sync()`** (sync) or **`await`** (async) before using **`with`** / **`async with`**, and the quick-reference share step switches from nonexistent **`MyEnv.from_hub(...)`** to **`MyEnv.from_env("you/my-env").sync()`**. The guides now spell out why using the handle directly in a context manager raises **`TypeError`**, include a full async example, and the published guide links to **Async vs Sync Usage**; the **generate-openenv-env** skill reference is updated in parallel so agents do not regenerate stale snippets.
> 
> **`task-api.md`** gets the same one-line fix: **`LatexOCREnv.from_docker_image(...).sync()`** in the training-loop example.
> 
> Two regression tests in **`test_generic_client.py`** lock in the documented **sync** (`from_docker_image(...).sync()` + `with` + `reset()`) and **async** (`await from_docker_image(...)` + `async with` + `reset()`) paths, asserting a concrete **`StepResult`**, a single WebSocket, and container teardown. **No library/runtime behavior changes.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac3d3df1cd7d237fc0c4bb19c89aab25eed90824. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->