### PR TITLE
Make coding_env's documented constructor arguments actually work

### DIFF
--- a/envs/coding_env/server/python_codeact_env.py
+++ b/envs/coding_env/server/python_codeact_env.py
@@ -13,7 +13,12 @@ Python code actions using PyExecutor.
 
 import uuid
 
-from openenv.core.env_server.interfaces import Action, Environment, Observation
+from openenv.core.env_server.interfaces import (
+    Action,
+    Environment,
+    Observation,
+    Transform,
+)
 
 from ..models import CodeAction, CodeObservation, CodeState
 from .python_executor import PyExecutor
@@ -45,9 +50,13 @@ class PythonCodeActEnv(Environment):
 
     def __init__(
         self,
+        transform: Transform | None = None,
+        additional_imports: list[str] | None = None,
     ):
-        self.transform = create_safe_coding_transform()
-        self._executor = PyExecutor()
+        self._transform = transform
+        self._additional_imports = additional_imports
+        self.transform = transform or create_safe_coding_transform()
+        self._executor = PyExecutor(additional_imports=additional_imports)
         self._state = CodeState()
 
     def reset(self) -> Observation:
@@ -63,10 +72,10 @@ class PythonCodeActEnv(Environment):
         self._state.last_exit_code = 0
 
         # Reset executor to clear any previously defined variables/functions
-        self._executor = PyExecutor()
+        self._executor = PyExecutor(additional_imports=self._additional_imports)
 
         # Reset transform to clear any accumulated state
-        self.transform = create_safe_coding_transform()
+        self.transform = self._transform or create_safe_coding_transform()
 
         # Return initial observation
         observation = CodeObservation(


### PR DESCRIPTION
## Summary

`PythonCodeActEnv`'s docstring documents two constructor arguments, `transform` and `additional_imports` (with a `["numpy", "pandas", "matplotlib"]` example), but `__init__` accepts neither, so there is no way to authorize an import outside the executor's default allowlist. `PyExecutor` already takes `additional_imports`; the env just never passed anything. This makes the documented arguments work and threads them through `reset()`, which rebuilds the executor and the transform on every episode and would otherwise discard them.

No behaviour change when the arguments are omitted.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] New environment
- [ ] Refactoring

## Alignment Checklist

Before submitting, verify:
- [x] I have read `.claude/docs/PRINCIPLES.md` and this PR aligns with our principles
- [x] I have checked `.claude/docs/INVARIANTS.md` and no invariants are violated
- [x] I have run `/pre-submit-pr` (or `bash .claude/hooks/lint.sh` and tests) and addressed all issues

## RFC Status
- [x] Not required (bug fix, docs, minor refactoring)
- [ ] RFC exists: #___
- [ ] RFC needed (will create before merge)

## Test Plan

Lint and tests:

```sh
bash .claude/hooks/lint.sh          # coding_env/server/python_codeact_env.py is clean
bash .claude/hooks/check-debug.sh   # clean for the changed file
PYTHONPATH=src:envs uv run pytest tests/envs/test_coding_env_integration.py \
  tests/envs/test_coding_tools_environment.py -q     # 4 passed, 13 skipped
```

`lint.sh` reports pre-existing formatting failures in other envs on a clean tree (as `AGENTS.md` notes); the file changed here is not among them.

Behaviour, including the `reset()` path that motivated the second half of the change:

```python
from coding_env.models import CodeAction
from coding_env.server.python_codeact_env import PythonCodeActEnv

# default unchanged: heapq is still refused
env = PythonCodeActEnv()
env.reset()
assert env.step(CodeAction(code="import heapq")).exit_code == 1

# authorized, and still authorized after reset() rebuilds the executor
env = PythonCodeActEnv(additional_imports=["heapq"])
env.reset()
assert env.step(CodeAction(code="import heapq")).exit_code == 0
assert env.step(CodeAction(code="print(heapq.nsmallest(2, [5, 1, 3]))")).stdout.strip() == "[1, 3]"
```

Verified against `smolagents` 1.26.0.

A deployment selects its own allowlist through the factory that `create_app` already accepts:

```python
app = create_app(
    functools.partial(PythonCodeActEnv, additional_imports=["heapq", "bisect"]),
    CodeAction,
    CodeObservation,
    env_name="coding_env",
)
```

## Claude Code Review

This PR was written with AI assistance (Claude Code). `/alignment-review` was not run as a slash command; the steps in `.claude/skills/alignment-review/SKILL.md` were followed manually and the result is below.

**Tier 1 (mechanical)**: none outstanding. Lint and debug hooks are clean for the changed file, the two `coding_env` test files pass, no new imports beyond `Transform` from the same module the file already imports from, no credential or logging surface touched.

**Tier 2 (alignment)**: one flag, raised deliberately rather than assumed benign.

**ALIGNMENT FLAG**: this makes the sandbox's Python import allowlist configurable by whoever deploys the environment.
- **Principle/RFC at stake**: `INVARIANTS.md`, Security Invariants → "Container isolation".
- **The concern**: `coding_env` executes model-written code, so its import allowlist is a security surface. This PR does not widen the default (an omitted argument behaves exactly as before, and `import heapq` is still refused), and the executor still runs inside the container, so isolation itself is unchanged. What changes is that widening becomes an explicit, per-deployment decision instead of an unreachable one. Worth a reviewer's eye on whether the env should instead ship a fixed, larger default allowlist, which would be a different and more opinionated change.
- **Suggested reviewer**: left to maintainers to route. The relevant invariant section is "Security Invariants → Container isolation"; I did not want to ping a `git blame` author who may not own that call.

Checked against RFCs in `rfcs/`: no conflict. The two "allowlist" mentions in `002-env-spec.md` and `008-environment-auto-validation.md` (both In Review) are about network egress policy, not Python imports.

**Not addressed here, on purpose**: `PythonCodeActEnv` does not use the `Environment[ActT, ObsT, StateT]` generics that `INVARIANTS.md` requires. That is pre-existing and out of scope for this fix.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Enables per-deployment widening of the Python import allowlist for model-executed code; defaults stay the same but deployers can expand the sandbox surface.
> 
> **Overview**
> **Wires up `PythonCodeActEnv`'s documented constructor options** so callers can pass an optional observation `transform` and extra Python modules to allow beyond `DEFAULT_SAFE_IMPORTS`.
> 
> `additional_imports` is merged with the default safe list via `_authorized_imports` and passed into `PyExecutor` on init and on every `reset()`, so widened imports are not dropped when the executor is recreated. An explicit `transform` is stored and reused on `reset()` instead of always building a new safe coding transform. **Default behavior is unchanged** when both arguments are omitted.
> 
> Adds `tests/envs/test_coding_codeact_env.py` covering default allowlist, merged imports (including after `reset()`), and transform persistence.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db06563e68f1678b2b00af9a9c26779919d2adce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->