### PR TITLE
fix(textarena): forward seed to underlying TextArena env on reset

### DIFF
--- a/envs/textarena_env/server/environment.py
+++ b/envs/textarena_env/server/environment.py
@@ -188,7 +188,7 @@ class TextArenaEnvironment(Environment):
         if hasattr(env, "full_observations"):
             env.full_observations = {}
 
-        self._ta_env.reset(num_players=self.num_players)
+        self._ta_env.reset(num_players=self.num_players, seed=seed)
 
         for provider in self._reward_providers:
             provider.reset()

--- a/tests/envs/test_textarena_environment.py
+++ b/tests/envs/test_textarena_environment.py
@@ -65,3 +65,21 @@ def test_wordle_reset_clears_accumulated_state():
     # Verify the prompts are actually the same content
     assert obs1.prompt == obs2.prompt
     assert obs2.prompt == obs3.prompt
+
+
+def test_reset_seed_is_forwarded_to_textarena():
+    """`reset(seed=...)` must reach the underlying TextArena env.
+
+    Regression test: the seed was previously accepted but discarded, so two
+    resets with the same seed drew two different secret words.
+    """
+    pytest.importorskip("textarena", reason="textarena not installed")
+    env = TextArenaEnvironment(env_id="Wordle-v0", num_players=1)
+
+    env.reset(seed=1234)
+    first_word = env._ta_env.state.game_state["secret_word"]
+
+    env.reset(seed=1234)
+    second_word = env._ta_env.state.game_state["secret_word"]
+
+    assert first_word == second_word


### PR DESCRIPTION
## Problem

`TextArenaEnvironment.reset()` takes a `seed` parameter (required by the
`Environment` base class interface) but never forwards it to the wrapped
TextArena env's own `reset()`. TextArena's `reset(num_players, seed=None)`
does accept a seed - it was just being dropped on the way through.

Result: `reset(seed=1234)` called repeatedly draws a different secret word
every time, even though the signature advertises reproducibility.

## Fix

Pass `seed` through in `TextArenaEnvironment.reset()`:

```python
self._ta_env.reset(num_players=self.num_players, seed=seed)
```

(Left the constructor's initial `reset()` call alone - there's no seed in
scope there.)

## Test plan

- Added `test_reset_seed_is_forwarded_to_textarena`, which resets twice with
  the same seed and asserts the secret word matches. Confirmed it fails on
  `main` (different word each time) and passes with the fix.
- `PYTHONPATH=src:envs uv run pytest tests/ -v` - full suite passes
  (1653 passed, 133 skipped, no failures).
- `uv run ruff format --check` / `ruff check` on the touched files - clean.
- Manually reproduced the bug and the fix outside pytest with real
  `textarena` installed (`Wordle-v0`, seed 1234 vs varying).

Fixes #1102

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-parameter pass-through on reset with a targeted regression test; no auth, data, or infrastructure changes.
> 
> **Overview**
> **`TextArenaEnvironment.reset()` now passes `seed` through** to the wrapped TextArena env (`self._ta_env.reset(..., seed=seed)`). Previously the OpenEnv `reset(seed=...)` argument was ignored, so repeated resets with the same seed still randomized game setup (e.g. different Wordle secret words).
> 
> A **regression test** resets `Wordle-v0` twice with `seed=1234` and asserts the secret word matches.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 66c0bf58b04c7f4f9f69bbbe53c24c5f5c23aca2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->