### PR TITLE
fix(client): drop the socket on a receive timeout instead of reusing it

### DIFF
--- a/src/openenv/core/env_client.py
+++ b/src/openenv/core/env_client.py
@@ -596,7 +596,7 @@ class EnvClient(ABC, Generic[ActT, ObsT, StateT]):
         assert self._ws is not None
         try:
             raw = await asyncio.wait_for(self._ws.recv(), timeout=self._message_timeout)
-        except asyncio.TimeoutError:
+        except (asyncio.TimeoutError, asyncio.CancelledError):
             # The server may still write the response for this request to the
             # socket after we give up waiting on it. If we left the socket
             # open, the next call's `_receive()` would read that stale frame
@@ -604,6 +604,11 @@ class EnvClient(ABC, Generic[ActT, ObsT, StateT]):
             # response after that would be shifted by one for the life of
             # the connection. Drop the socket so the next `_send()` opens a
             # fresh one instead of reusing a desynced one.
+            #
+            # An outer `asyncio.wait_for` around the whole call (e.g. a
+            # caller-imposed deadline on step()) cancels this await with
+            # CancelledError, not our own message_timeout's TimeoutError --
+            # same desync, different exception, so both are caught here.
             ws = self._ws
             self._ws = None
             self._ws_loop = None

--- a/src/openenv/core/env_client.py
+++ b/src/openenv/core/env_client.py
@@ -594,7 +594,24 @@ class EnvClient(ABC, Generic[ActT, ObsT, StateT]):
         never sent. The next complete operation may reconnect in `_send()`.
         """
         assert self._ws is not None
-        raw = await asyncio.wait_for(self._ws.recv(), timeout=self._message_timeout)
+        try:
+            raw = await asyncio.wait_for(self._ws.recv(), timeout=self._message_timeout)
+        except asyncio.TimeoutError:
+            # The server may still write the response for this request to the
+            # socket after we give up waiting on it. If we left the socket
+            # open, the next call's `_receive()` would read that stale frame
+            # and silently pair it with an unrelated request -- and every
+            # response after that would be shifted by one for the life of
+            # the connection. Drop the socket so the next `_send()` opens a
+            # fresh one instead of reusing a desynced one.
+            ws = self._ws
+            self._ws = None
+            self._ws_loop = None
+            try:
+                await ws.close()
+            except Exception:
+                pass  # Best effort
+            raise
         return json.loads(raw)
 
     async def _send_and_receive(self, message: Dict[str, Any]) -> Dict[str, Any]:

--- a/tests/test_core/test_generic_client.py
+++ b/tests/test_core/test_generic_client.py
@@ -1430,6 +1430,63 @@ class TestForeignLoopReconnect:
         mock_connect.assert_called_once()
         assert client._ws is replacement_ws
 
+    @pytest.mark.asyncio
+    async def test_receive_cancelled_by_outer_deadline_drops_socket_so_next_call_reconnects(
+        self,
+    ):
+        """An outer `asyncio.wait_for` around the whole call cancels
+        `_receive()` with `asyncio.CancelledError`, not the client's own
+        `asyncio.TimeoutError` -- a caller-imposed deadline (e.g. a step
+        call wrapped in its own timeout) hits this path even when
+        `message_timeout_s` itself never fires.
+
+        Regression for the gap in the #1143 fix: only `asyncio.TimeoutError`
+        was caught, so this path left the socket open and desynced exactly
+        like the original bug.
+        """
+
+        class NeverResponds:
+            state = State.OPEN
+
+            async def send(self, _message):
+                pass
+
+            async def recv(self):
+                await asyncio.sleep(10)
+
+            async def close(self):
+                self.state = State.CLOSED
+
+        client = GenericEnvClient(
+            base_url="http://localhost:8000", message_timeout_s=10
+        )
+        original_ws = NeverResponds()
+        client._ws = original_ws
+        client._ws_loop = asyncio.get_running_loop()
+
+        with pytest.raises(asyncio.TimeoutError):
+            await asyncio.wait_for(
+                client._send_and_receive({"type": "state"}), timeout=0.05
+            )
+
+        assert client._ws is None
+        assert original_ws.state == State.CLOSED
+
+        replacement_ws = AsyncMock()
+        replacement_ws.state = State.OPEN
+        replacement_ws.recv.return_value = '{"type": "state", "data": {}}'
+
+        async def fake_ws_connect(*args, **kwargs):
+            return replacement_ws
+
+        with patch(
+            "openenv.core.env_client.ws_connect", side_effect=fake_ws_connect
+        ) as mock_connect:
+            await client._send_and_receive({"type": "state"})
+
+        mock_connect.assert_called_once()
+        assert client._ws is replacement_ws
+
 
 # ============================================================================
 # Integration Tests (require running server)

--- a/tests/test_core/test_generic_client.py
+++ b/tests/test_core/test_generic_client.py
@@ -1379,6 +1379,57 @@ class TestForeignLoopReconnect:
         mock_connect.assert_not_called()
         assert client._ws is original_ws
 
+    @pytest.mark.asyncio
+    async def test_receive_timeout_drops_socket_so_next_call_reconnects(self):
+        """A response that arrives after we time out must not be read by the
+        *next* call.
+
+        Regression test for #1143: leaving the timed-out socket open let the
+        server's late response for the abandoned request sit in the buffer,
+        where the next `_receive()` silently read it as its own -- and every
+        response after that was shifted by one for the life of the connection.
+        """
+
+        class NeverResponds:
+            state = State.OPEN
+
+            async def send(self, _message):
+                pass
+
+            async def recv(self):
+                await asyncio.sleep(10)
+
+            async def close(self):
+                self.state = State.CLOSED
+
+        client = GenericEnvClient(
+            base_url="http://localhost:8000", message_timeout_s=0.05
+        )
+        original_ws = NeverResponds()
+        client._ws = original_ws
+        client._ws_loop = asyncio.get_running_loop()
+
+        with pytest.raises(asyncio.TimeoutError):
+            await client._send_and_receive({"type": "state"})
+
+        assert client._ws is None
+        assert original_ws.state == State.CLOSED
+
+        replacement_ws = AsyncMock()
+        replacement_ws.state = State.OPEN
+        replacement_ws.recv.return_value = '{"type": "state", "data": {}}'
+
+        async def fake_ws_connect(*args, **kwargs):
+            return replacement_ws
+
+        with patch(
+            "openenv.core.env_client.ws_connect", side_effect=fake_ws_connect
+        ) as mock_connect:
+            await client._send_and_receive({"type": "state"})
+
+        mock_connect.assert_called_once()
+        assert client._ws is replacement_ws
+
 
 # ============================================================================
 # Integration Tests (require running server)


### PR DESCRIPTION
## Problem

`EnvClient._receive()` waits for the next frame on the WebSocket that
carried the request:

```python
raw = await asyncio.wait_for(self._ws.recv(), timeout=self._message_timeout)
```

If that wait times out, the exception propagated with the socket left open
and untouched. The server (`/ws` / `/mcp` handlers) processes one message at
a time and writes its reply whenever it finishes, regardless of whether the
client is still listening - so the response for the timed-out call sits in
the socket's receive buffer. The *next* `step()` / `reset()` / `state()`
call reads that stale frame back and treats it as its own response, and
every response after that is shifted by one for the life of the connection
- wrong `observation`/`reward`/`done` handed back silently, no error raised.

## Fix

On `asyncio.TimeoutError` specifically, close and drop `self._ws` (and
`self._ws_loop`) before re-raising, so the next `_send()` opens a fresh
connection instead of reading a desynced one. Left every other exception
path alone - a socket the far end actually closed, or one that raises for
another reason, should keep its existing (already-correct) handling, which
is exercised by the existing `test_receive_does_not_reconnect_after_request_was_sent`
test.

## Test plan

- Added `test_receive_timeout_drops_socket_so_next_call_reconnects`: a fake
  socket that never responds triggers the timeout, asserts the client drops
  and closes that socket, then asserts the *next* call opens a fresh one
  rather than reusing it. Confirmed it fails on `main` (`client._ws` stays
  the same timed-out socket) and passes with the fix.
- `PYTHONPATH=src:envs uv run pytest tests/ -v` - full suite passes
  (1654 passed, 133 skipped, no failures).
- `uv run ruff format --check` / `ruff check` on the touched files - clean.

Fixes #1143

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core WebSocket receive/error handling for all environment clients; behavior is better-defined and heavily tested, but incorrect edge cases could still affect episode correctness or session cleanup.
> 
> **Overview**
> Fixes **silent request/response misalignment** when `EnvClient._receive()` stops waiting but the server may still send a reply (#1143). On **`asyncio.TimeoutError`** or **`asyncio.CancelledError`** (e.g. an outer `wait_for` on `step()`), the client now **clears `_ws` / `_ws_loop`** so the next operation reconnects instead of reading a stale frame.
> 
> Socket teardown is **`_best_effort_close` in a background task** (tracked in **`_pending_close_tasks`**) so a slow WebSocket close handshake does not block the caller’s deadline; **`close()` / `_close_async()`** still **`gather`s** those tasks so sync shutdown does not tear down the loop mid-handshake.
> 
> Adds regression tests for timeout reconnect, cancel reconnect, non-blocking close on deadline, and **`close()` waiting on pending background closes**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 584af3319ce731c285050d6fa5776d2f3fbafc31. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->