### PR TITLE
Forward volume mounts in LocalDockerProvider

### DIFF
--- a/src/openenv/core/containers/runtime/providers.py
+++ b/src/openenv/core/containers/runtime/providers.py
@@ -219,7 +219,11 @@ class LocalDockerProvider(ContainerProvider):
         # Add volume mounts before the image name.
         if volumes:
             for source, config in volumes.items():
-                bind = config["bind"]
+                bind = config.get("bind")
+                if not bind:
+                    raise ValueError(
+                        f"Volume config for {source!r} must include a non-empty 'bind'"
+                    )
                 mode = config.get("mode")
                 volume_spec = f"{source}:{bind}"
                 if mode:

--- a/src/openenv/core/containers/runtime/providers.py
+++ b/src/openenv/core/containers/runtime/providers.py
@@ -10,7 +10,7 @@ This module provides a pluggable architecture for different container providers
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Any, Dict, Optional, Sequence, TypeVar
+from typing import Any, Dict, Mapping, Optional, Sequence, TypeVar
 
 _ContainerProviderT = TypeVar("_ContainerProviderT", bound="ContainerProvider")
 
@@ -175,14 +175,23 @@ class LocalDockerProvider(ContainerProvider):
                 Port to expose. If `None`, finds an available port.
             env_vars (`dict`, *optional*):
                 Environment variables for the container.
-            **kwargs:
-                Additional Docker run options.
+            volumes (`dict`, *optional*):
+                Mapping of host paths or volume names to mount configuration.
+                Each configuration must contain a `bind` container path and may
+                contain a `mode` such as `"ro"` or `"rw"`.
 
         Returns:
             `str`: Base URL to connect to the container.
         """
         import subprocess
         import time
+
+        allowed_kwargs = {"volumes"}
+        unknown = set(kwargs) - allowed_kwargs
+        if unknown:
+            raise ValueError(f"Unsupported kwargs for LocalDockerProvider: {unknown}")
+
+        volumes: Optional[Mapping[str, Mapping[str, str]]] = kwargs.get("volumes")
 
         # Find available port if not specified
         if port is None:
@@ -206,6 +215,16 @@ class LocalDockerProvider(ContainerProvider):
         if env_vars:
             for key, value in env_vars.items():
                 cmd.extend(["-e", f"{key}={value}"])
+
+        # Add volume mounts before the image name.
+        if volumes:
+            for source, config in volumes.items():
+                bind = config["bind"]
+                mode = config.get("mode")
+                volume_spec = f"{source}:{bind}"
+                if mode:
+                    volume_spec = f"{volume_spec}:{mode}"
+                cmd.extend(["--volume", volume_spec])
 
         # Add image
         cmd.append(image)

--- a/tests/test_core/test_local_docker_provider.py
+++ b/tests/test_core/test_local_docker_provider.py
@@ -1,0 +1,46 @@
+import subprocess
+import time
+from types import SimpleNamespace
+
+from openenv.core.containers.runtime import LocalDockerProvider
+
+
+def test_start_container_forwards_volume_mounts(monkeypatch):
+    commands = []
+
+    def fake_run(command, **kwargs):
+        commands.append(command)
+        return SimpleNamespace(stdout="container-id\n")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    monkeypatch.setattr(time, "sleep", lambda _: None)
+
+    provider = LocalDockerProvider()
+    monkeypatch.setattr(
+        provider, "_generate_container_name", lambda _: "test-container"
+    )
+
+    base_url = provider.start_container(
+        "retro-env:latest",
+        port=8123,
+        volumes={
+            "/host/roms": {
+                "bind": "/roms",
+                "mode": "ro",
+            }
+        },
+    )
+
+    assert base_url == "http://localhost:8123"
+    assert commands[1] == [
+        "docker",
+        "run",
+        "-d",
+        "--name",
+        "test-container",
+        "-p",
+        "8123:8000",
+        "--volume",
+        "/host/roms:/roms:ro",
+        "retro-env:latest",
+    ]

--- a/tests/test_core/test_local_docker_provider.py
+++ b/tests/test_core/test_local_docker_provider.py
@@ -3,7 +3,6 @@ import time
 from types import SimpleNamespace
 
 import pytest
-
 from openenv.core.containers.runtime import LocalDockerProvider
 
 

--- a/tests/test_core/test_local_docker_provider.py
+++ b/tests/test_core/test_local_docker_provider.py
@@ -2,10 +2,12 @@ import subprocess
 import time
 from types import SimpleNamespace
 
+import pytest
+
 from openenv.core.containers.runtime import LocalDockerProvider
 
 
-def test_start_container_forwards_volume_mounts(monkeypatch):
+def make_provider(monkeypatch):
     commands = []
 
     def fake_run(command, **kwargs):
@@ -19,6 +21,11 @@ def test_start_container_forwards_volume_mounts(monkeypatch):
     monkeypatch.setattr(
         provider, "_generate_container_name", lambda _: "test-container"
     )
+    return provider, commands
+
+
+def test_start_container_forwards_volume_mounts(monkeypatch):
+    provider, commands = make_provider(monkeypatch)
 
     base_url = provider.start_container(
         "retro-env:latest",
@@ -27,11 +34,15 @@ def test_start_container_forwards_volume_mounts(monkeypatch):
             "/host/roms": {
                 "bind": "/roms",
                 "mode": "ro",
-            }
+            },
+            "game-data": {
+                "bind": "/data",
+            },
         },
     )
 
     assert base_url == "http://localhost:8123"
+    assert commands[0] == ["docker", "version"]
     assert commands[1] == [
         "docker",
         "run",
@@ -42,5 +53,32 @@ def test_start_container_forwards_volume_mounts(monkeypatch):
         "8123:8000",
         "--volume",
         "/host/roms:/roms:ro",
+        "--volume",
+        "game-data:/data",
         "retro-env:latest",
     ]
+
+
+def test_start_container_rejects_volume_without_bind(monkeypatch):
+    provider, _ = make_provider(monkeypatch)
+
+    with pytest.raises(
+        ValueError,
+        match="Volume config for '/host/roms' must include a non-empty 'bind'",
+    ):
+        provider.start_container(
+            "retro-env:latest",
+            port=8123,
+            volumes={"/host/roms": {}},
+        )
+
+
+def test_start_container_rejects_unsupported_kwargs(monkeypatch):
+    provider, _ = make_provider(monkeypatch)
+
+    with pytest.raises(ValueError, match="Unsupported kwargs for LocalDockerProvider"):
+        provider.start_container(
+            "retro-env:latest",
+            port=8123,
+            privileged=True,
+        )


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- translate `volumes` passed to `LocalDockerProvider.start_container()` into Docker `--volume` arguments before the image name
- validate required volume bindings and reject unsupported provider kwargs instead of failing opaquely or silently dropping options
- add mocked regression coverage for read-only and default-mode mounts, malformed volume configuration, and unsupported kwargs

Closes #1150

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] New environment
- [ ] Refactoring

## Alignment Checklist

Before submitting, verify:
- [x] I have read `.claude/docs/PRINCIPLES.md` and this PR aligns with our principles
- [x] I have checked `.claude/docs/INVARIANTS.md` and no invariants are violated
- [x] I have run `/pre-submit-pr` (or `bash .claude/hooks/lint.sh` and tests) and addressed all issues

## RFC Status
- [x] Not required (bug fix, docs, minor refactoring)
- [ ] RFC exists: #___
- [ ] RFC needed (will create before merge)

## Test Plan
- `PYTHONPATH=src:envs .venv/bin/python -m pytest tests/test_core/test_local_docker_provider.py -v` (3 passed)
- full repository suite via `.claude/hooks/test.sh` (1,636 passed, 96 skipped, 37 deselected)
- `.venv/bin/python -m ruff format src/openenv/core/containers/runtime/providers.py tests/test_core/test_local_docker_provider.py --check`
- `.venv/bin/python -m ruff check src/ tests/`
- `.venv/bin/python -m usort check src/openenv/core/containers/runtime/providers.py tests/test_core/test_local_docker_provider.py`
- `.claude/hooks/post-push-pr.sh` (open, conflict-free, and current with `main`)

The repository-wide usort check continues to report the two documented pre-existing files (`tests/envs/test_grid_world.py` and `tests/envs/test_julia_env.py`); both changed files pass usort.

## Claude Code Review
- Tier 1: review feedback on malformed volume errors, command assertion clarity, and edge-case coverage has been addressed
- Tier 2: no alignment concerns identified
- Invariants: explicit caller-requested mounts remain consistent with the container-isolation exception for explicitly mounted volumes
- RFC: not required; this is a narrow implementation fix without a public signature change
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://huggingface.slack.com/archives/C0C0FAQHZTR/p1789065312092259?thread_ts=1789065312.092259&cid=C0C0FAQHZTR)

<div><a href="https://cursor.com/agents/bc-3bf83331-c710-52ea-8aa0-7f0af05eed0f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3bf83331-c710-52ea-8aa0-7f0af05eed0f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

